### PR TITLE
Add functionality of using 32-byte passphrase

### DIFF
--- a/src/utils/ecryptfs-setup-private
+++ b/src/utils/ecryptfs-setup-private
@@ -23,10 +23,12 @@ usage() {
 	echo "
 Usage:
 
-$0 [-f|--force] [-w|--wrapping] [--nopwcheck] [-n|--no-fnek]
+$0 [--32] [-f|--force] [-w|--wrapping] [--nopwcheck] [-n|--no-fnek]
   [-u|--username USER] [-l|--loginpass LOGINPASS]
   [-m|--mountpass MOUNTPASS]
 
+ --32             Use 32-byte (highest) passphrase rather than
+                  the default 16-byte one
  -f, --force      Force overwriting of an existing setup
  -w, --wrapping   Use an independent wrapping passphrase,
                   different from the login passphrase
@@ -122,6 +124,10 @@ while [ ! -z "$1" ]; do
 		-l|--loginpass)
 			LOGINPASS="$2"
 			shift 2
+		;;
+		--32)
+			KEYBYTES=32
+			shift 1
 		;;
 		-m|--mountpass)
 			MOUNTPASS="$2"
@@ -393,7 +399,7 @@ if [ $? -ne 0 ]; then
 	error "$(gettext 'Could not add passphrase to the current keyring')"
 fi
 sig=`echo "$response" | grep "Inserted auth tok" | sed "s/^.*\[//" | sed "s/\].*$//"`
-if ! echo "$sig" | egrep -qs "^[0-9a-fA-F]{$KEYBYTES,$KEYBYTES}$"; then
+if ! echo "$sig" | egrep -qs "^[0-9a-fA-F]{16}$"; then
 	error "$(gettext 'Could not obtain the key signature')"
 fi
 temp=`mktemp`


### PR DESCRIPTION
I was fascinated with ecryptfs and annoyed by the error message given out when $KEYBYTES was set to 32 arbitrarily. Finally I found line 402 in my proposal is the key. Because the number of bytes of "auth tok" is always 16 no matter how many bytes the passphrase is, the "$KEYBYTES,$KEYBYTES" should be replaced with 16.

I have made a few tests and it seems working fine. The new 32-byte passphrase has been proved by ecryptfs-unwrap-passphrase.

P.S. This is my first proposal in GitHub ~~ Hope that you can accept that.
